### PR TITLE
Update sh-entrypoint-scrapy up to 0.8.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ Jinja2==2.7.3
 slackclient==1.0.0
 
 # Scrapinghub Kumo contract
-scrapinghub-entrypoint-scrapy==0.8.7
+scrapinghub-entrypoint-scrapy==0.8.8


### PR DESCRIPTION
Related with fixing monitoring addon in https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/pull/28.
